### PR TITLE
change infiles.extend method in eval_tiles to produce flat list of jpg

### DIFF
--- a/eval_imrecog/test_class_tiles.py
+++ b/eval_imrecog/test_class_tiles.py
@@ -139,9 +139,10 @@ def norm_im(image_path):
 # =========================================================
 def eval_tiles(label, direc, numero, classifier_file, x, n):
    #print(label)
+   #get list of jpg files (or jpeg, JPG, JPEG) 
    infiles = []
-   for ext in ['jpg', 'JPG', 'jpeg', 'JPEG']:
-      infiles.append(glob(direc+os.sep+label+os.sep+'*.'+ext)[:numero])
+   for ext in ['*.jpg', '*.jpeg']:
+      infiles.extend(glob(direc + os.sep + label + os.sep + ext)[:numero])
 
    Z = []
    for image_path in infiles:


### PR DESCRIPTION
Found error when running eval_imrecog\test_class_tile.py.  Changed method for generating list of jpg images from infiles.append to infiles.extend in order to create a flat list (instead of a list of lists).  Tested and this works for jpg with any common extension ('*.jpg/*.JPG/*.jpeg/*.JPEG').